### PR TITLE
Add ability to edit track activities

### DIFF
--- a/gaiagps/shell/track.py
+++ b/gaiagps/shell/track.py
@@ -15,7 +15,7 @@ class Track(command.Command):
     removing, and renaming them.
     """
 
-    _editable_properties = ('color', 'notes', 'public', 'title', 'revision')
+    _editable_properties = ('color', 'notes', 'public', 'title', 'revision', 'activities')
 
     @staticmethod
     def opts(parser):


### PR DESCRIPTION
Tested on a track with no activity:
![Screenshot from 2022-02-21 11-20-39](https://user-images.githubusercontent.com/20446774/155009006-8438dcf8-da97-4f8a-b2f6-32a2969af2ff.png)

Ran 
```
 python gaiagps/shell/__main__.py track edit -i "Chessler park"
```

Edited yaml file to read as follows, note the "activities" field
``` 
# This is a YAML document. Take care not to change the format!
# Available colors are: red lightred purple navy blue lightblue teal
# aqua forestgreen green lightgreen goldenrod yellow amber orange
# firetruck brown grey slate black

- features:
  - properties:
      activities: [hiking]
      color: '#0479FF'
      notes: ''
      public: false
      revision: 1645467614
      title: Chessler park
  id: d948fab7bd3c1381f9ca79328d322bce
```

Refreshed and saw activity updated
![Screenshot from 2022-02-21 11-21-41](https://user-images.githubusercontent.com/20446774/155009096-6f826075-a7fd-47da-86e6-e754265411cf.png)
