### PR TITLE
Allow auth by sessionid

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,15 +27,14 @@ CLI Usage
 
 For more information on usage, see the `full documentation <https://gaiagpsclient.readthedocs.io/en/latest/>`_. Below is a quick introduction to get you started. For more common usage recipes, check out the `cookbook <https://gaiagpsclient.readthedocs.io/en/latest/cookbook.html>`_.
 
-The command line client will attempt to login to gaiagps.com only when necessary, caching the session credentials whenever possible. Thus, at least the first use requires your Gaia credentials, and any time after that session expires. After installation, try testing your connection, which will perform a login and validate that communication is possible:
+As of 2023, the only way to authenticate the client to gaiagps is to login with the browser and extract a sessionid cookie. Use a browser extension or the development tools to copy the sessionid cookie value from a logged-in session. Pass that to the command-line tool like this:
 
 .. code-block:: shell
 
-  $ gaiagps --user user@domain.com test
-  Password:
+  $ gaiagps --sessionid asd9sdjd8errr4n8ssff35sff test
   Success!
 
-After that, you can perform commands without providing your username or password.
+If you see the "Success!" message then you are logged in. Once the session with gaiagps expires, you will need to repeat the procedure.
 
 The available high-level commands are displayed with ``--help``::
 

--- a/gaiagps/shell/__init__.py
+++ b/gaiagps/shell/__init__.py
@@ -4,6 +4,7 @@ import getpass
 import http.cookiejar
 import logging
 import os
+import requests
 import sys
 import traceback
 
@@ -25,12 +26,12 @@ def cookiejar():
 
     jar = http.cookiejar.LWPCookieJar(cookiepath)
     if os.path.exists(cookiepath):
-        jar.load()
+        jar.load(ignore_discard=True)
 
     try:
         yield jar
     finally:
-        jar.save()
+        jar.save(ignore_discard=True)
 
 
 def main(args=None):
@@ -39,6 +40,8 @@ def main(args=None):
     parser.add_argument('--user', help='Gaia username')
     parser.add_argument('--pass', metavar='PASS', dest='pass_',
                         help='Gaia password (prompt if unspecified)', )
+    parser.add_argument('--sessionid',
+                        help='Manually set the sessionid cookie value')
     parser.add_argument('--debug', help='Enable debug output',
                         action='store_true')
     parser.add_argument('--verbose', help='Enable verbose output',
@@ -90,6 +93,11 @@ def main(args=None):
             args.pass_ = getpass.getpass()
 
         with cookiejar() as cookies:
+            if args.sessionid:
+                cookies.set_cookie(requests.cookies.create_cookie(
+                    domain='gaiagps.com', name='sessionid',
+                    value=args.sessionid))
+
             try:
                 client = apiclient.GaiaClient(args.user, args.pass_,
                                               cookies=cookies)


### PR DESCRIPTION
Since early 2023 GaiaGPS now enforces human-ness in the web login
path by hidden re-captcha. This breaks user/pass authentication in
gaiagpsclient (intentionally). This change adds the ability to provide
the sessionid cookie via --sessionid at the command-line. This will
be persisted in the cookiejar in the same way, so it is only required
to be done initially and whenever the session expires.

Fixes #10
